### PR TITLE
Fix accumulator initialisation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 __pycache__/
 *.py[cod]
 
+# Notebook Caches
+.ipynb_checkpoints/
+
+# Folder for testing
+.no_commit/
+
 # C extensions
 *.so
 

--- a/ILprofile.py
+++ b/ILprofile.py
@@ -6,6 +6,7 @@ import IsingLattice as il
 # use a relatively big lattice of 25x25 so that we get more accurate timing data
 n_rows = 25
 n_cols = 25
+save_profile = False
 
 lattice = il.IsingLattice(n_rows, n_cols)
 # record the time at which we start running
@@ -23,5 +24,6 @@ print("2000 steps took {} s".format(elapsed_time))
 
 prof.print_stats()
 
-#profiling data can be saved to a file and analysed with tools like pstats or SnakeViz
-#prof.dump_stats("ising.prof")
+# profiling data can be saved to a file and analysed with tools like pstats or SnakeViz
+if save_profile:
+    prof.dump_stats("ising.prof")

--- a/IsingLattice.py
+++ b/IsingLattice.py
@@ -6,12 +6,15 @@ class IsingLattice:
         self.n_rows = n_rows
         self.n_cols = n_cols
         self.lattice = np.random.choice([-1, 1], size=(n_rows, n_cols))
+
+        current_en = self.energy()
+        current_mag = self.magnetisation()
+
         # Running sums
-        self.E_tally = self.energy()
-        # NOTE: this only holds true on the first step.
-        self.E_sq_tally = self.E_tally**2
-        self.M_tally = self.magnetisation()
-        self.M_sq_tally = self.M_tally**2
+        self.E_tally = current_en
+        self.E2_tally = current_en**2
+        self.M_tally = current_mag
+        self.M2_tally = current_mag**2
 
         self.n_steps = 0
 

--- a/IsingLattice.py
+++ b/IsingLattice.py
@@ -1,16 +1,18 @@
 import numpy as np
 
-class IsingLattice:
 
+class IsingLattice:
     def __init__(self, n_rows, n_cols):
         self.n_rows = n_rows
         self.n_cols = n_cols
         self.lattice = np.random.choice([-1, 1], size=(n_rows, n_cols))
-        #Running sums
+        # Running sums
         self.E_tally = self.energy()
-        self.E2_tally = self.E**2
+        # NOTE: this only holds true on the first step.
+        self.E_sq_tally = self.E_tally**2
         self.M_tally = self.magnetisation()
-        self.M2_tally = self.M**2
+        self.M_sq_tally = self.M_tally**2
+
         self.n_steps = 0
 
     def energy(self):
@@ -27,20 +29,20 @@ class IsingLattice:
         """A single Monte-Carlo trial move. Attempts to flip a random spin.
         Returns a tuple with the energy and magnetisation of the new configuration.
         """
-        # complete this function so that it performs a single Monte Carlo step
+        # Complete this function so that it performs a single Monte Carlo step
         energy = self.energy()
-        # the following two lines will select the coordinates of the random spin for you
+        # The following two lines will select the coordinates of the random spin for you
         random_i = np.random.choice(range(0, self.n_rows))
         random_j = np.random.choice(range(0, self.n_cols))
-        # the following line will choose for you a random number in the range [0,1)
+        # The following line will choose for you a random number in the range [0,1)
         random_number = np.random.random()
         ...
 
     def statistics(self):
-        """Returns a tuple with the averaged values of energy, energy squared,
-        magnetisation, magnetisation squared, and the current step, in this order.
-        """
-        # complete this function so that it calculates the correct values for the averages of E, E*E (E2), M, M*M (M2), and returns them with Nsteps
+        """Returns the averaged values of energy, energy squared, magnetisation,
+        magnetisation squared, and the current step, in this order."""
+        # Complete this function so that it calculates the correct values for the
+        # averages of E, E*E (E2), M, M*M (M2), and returns them with Nsteps
         ...
 
     def delta_energy(self, i, j):


### PR DESCRIPTION
There was a mistake in the initial assignment to the squared accumulators.
The right-hand side had the old names.
I have updated this to add some temporary variables to avoid the confusion of writing 
`self.E2_tally = self.E_tally**2`, which is not in general true.

This PR also has tweaks to `.gitignore` and an option for whether to dump profiles.