### PR TITLE
(fix) use new accumulator names

### DIFF
--- a/ILtemperaturerange.py
+++ b/ILtemperaturerange.py
@@ -30,10 +30,10 @@ for t in temps:
     magnetisations.append(aveM)
     magnetisationsq.append(aveM2)
     # reset the IL object for the next cycle
-    il.E = 0.0
-    il.E2 = 0.0
-    il.M = 0.0
-    il.M2 = 0.0
+    il.E_tally = 0.0
+    il.E2_tally = 0.0
+    il.M_tally = 0.0
+    il.M2_tally = 0.0
     il.n_steps = 0
 fig = plt.figure()
 enerax = fig.add_subplot(2, 1, 1)


### PR DESCRIPTION
The IL temperature range script resets the statistics after each temperature, however, these weren't updated to reflect the new names.

Hopefully I've caught this before the students have got to this point.

We should probably avoid problems like this by using a `reset_statistics` method.
